### PR TITLE
Creating and writing the external file config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+/.idea/
+/dev.env
+/data/
+/processor-pre-ttl-sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:bullseye
+
+WORKDIR /service
+
+RUN apt clean && apt-get update && apt-get -y install alien
+
+# install dependencies
+
+
+COPY . .
+
+RUN ls /service
+
+RUN go build -o /service/main main.go
+
+RUN mkdir -p data
+
+# Add additional dependencies below ...
+
+ENTRYPOINT [ "/service/main" ]

--- a/Dockerfile_arm64
+++ b/Dockerfile_arm64
@@ -1,0 +1,16 @@
+FROM golang:bullseye
+
+WORKDIR /service
+
+RUN apt clean && apt-get update && apt-get -y install alien
+# install dependencies
+
+COPY . .
+
+RUN ls /service
+
+RUN go build -o /service/main main.go
+
+RUN mkdir -p data
+
+ENTRYPOINT [ "/service/main" ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+#!groovy
+
+ansiColor('xterm') {
+  node('executor') {
+
+  checkout scm
+
+  def authorName  = sh(returnStdout: true, script: 'git --no-pager show --format="%an" --no-patch')
+  def serviceName = env.JOB_NAME.tokenize("/")[1]
+
+  try {
+    stage("Build Container") {
+          sh "docker build ."
+    }
+
+    stage("Run Tests") {
+        sh "go test -v ./..."
+    }
+
+  } catch (e) {
+    slackSend(color: '#b20000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}) by ${authorName}")
+    throw e
+  }
+
+  slackSend(color: '#006600', message: "SUCCESSFUL: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL}) by ${authorName}")
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# TTL Sync Pre-Processor
+
+Given a dataset node ID, produces the external URLs for the latest TTL files in the format expected
+by [processor-pre-external-files](https://github.com/Pennsieve/processor-pre-external-files)
+
+To build:
+
+`docker build -t pennsieve/ttl-sync-pre-processor .`
+
+On arm64 architectures:
+
+`docker build -f Dockerfile_arm64 -t pennsieve/ttl-sync-pre-processor .`
+
+To run tests:
+
+` go test ./...`
+
+To run integration test:
+
+1. Given a dataset you want to test with, create an integration for the dataset and this pre-processor. Get the
+   integration id
+2. Copy `dev.env.example` to `dev.env`
+3. In dev.env update SESSION_TOKEN with a valid token and INTEGRATION_ID with the id from the first step.
+4. Run `./run-integration-test.sh dev.env`

--- a/dev.env.example
+++ b/dev.env.example
@@ -1,0 +1,6 @@
+SESSION_TOKEN=<token>
+PENNSIEVE_API_HOST=https://api.pennsieve.net
+PENNSIEVE_API_HOST2=https://api2.pennsieve.net
+INTEGRATION_ID=fake-integration-id
+INPUT_DIR=/service/data/input/${INTEGRATION_ID}
+OUTPUT_DIR=/service/data/output/${INTEGRATION_ID}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+  
+  ttl-sync-pre-processor:
+    env_file:
+      - dev.env
+    image: pennsieve/ttl-sync-pre-processor
+    volumes:
+      - ./data:/service/data
+    container_name: ttl-sync-pre-processor
+    build:
+      context: .
+      dockerfile: ./Dockerfile_arm64 # change to Dockerfile on Linux
+    entrypoint: /service/main

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,15 @@
+module github.com/pennsieve/processor-pre-ttl-sync
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c
+	github.com/stretchr/testify v1.9.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c h1:05YljpV++86gZsb2C5brFLz+lX5GRzpx5rW7GxcKpAk=
+github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c/go.mod h1:amoXpOYDD+iyV2nkqE+oyu7C85iFGnhEPN9Bfwb7+nE=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -1,0 +1,41 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// Level is the current log level of Default. To change the level at runtime, for example to DEBUG, call Level.Set(slog.LevelDebug)
+// Defaults to slog.LevelInfo
+var Level = new(slog.LevelVar)
+
+// Default is a *slog.Logger configured with a JSON handler and a level set by environment variable LOG_LEVEL
+// If LOG_LEVEL is not set, or is set to an unknown value, level defaults to slog.LevelInfo
+var Default *slog.Logger
+
+func init() {
+	configureLogging()
+}
+
+// configureLogging separated out from init() for testing with environment variables
+func configureLogging() {
+	envLogLevel := os.Getenv("LOG_LEVEL")
+	if len(envLogLevel) > 0 {
+		var level slog.Level
+		if err := level.UnmarshalText([]byte(envLogLevel)); err != nil {
+			slog.Error("error unmarshalling LOG_LEVEL value",
+				slog.String("LOG_LEVEL", envLogLevel),
+				slog.Any("error", err))
+			level = slog.LevelInfo
+		}
+		Level.Set(level)
+	}
+	h := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: Level})
+	slog.SetDefault(slog.New(h))
+	slog.Info("default log level set", slog.String("logging.Level", Level.String()))
+	Default = slog.Default()
+}
+
+func PackageLogger(packageName string) *slog.Logger {
+	return Default.With(slog.String("goPackage", packageName))
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"github.com/pennsieve/processor-pre-ttl-sync/logging"
+	"github.com/pennsieve/processor-pre-ttl-sync/preprocessor"
+	"log/slog"
+	"os"
+)
+
+var logger = logging.PackageLogger("main")
+
+func main() {
+	logger.Info("Hello")
+	m, err := preprocessor.FromEnv()
+	if err != nil {
+		logger.Error("error creating preprocessor", slog.Any("error", err))
+		os.Exit(1)
+	}
+
+	logger.Info("created ExternalFilesPreProcessor",
+		slog.String("integrationID", m.IntegrationID),
+		slog.String("inputDirectory", m.InputDirectory),
+		slog.String("outputDirectory", m.OutputDirectory),
+		slog.String("apiHost", m.Pennsieve.APIHost),
+		slog.String("api2Host", m.Pennsieve.API2Host),
+	)
+
+	if err := m.Run(); err != nil {
+		logger.Error("error running preprocessor", slog.Any("error", err))
+		os.Exit(1)
+	}
+}

--- a/models/integration.go
+++ b/models/integration.go
@@ -1,0 +1,7 @@
+package models
+
+type Integration struct {
+	Uuid          string `json:"uuid"`
+	ApplicationID int64  `json:"applicationId"`
+	DatasetNodeID string `json:"datasetId"`
+}

--- a/pennsieve/integrations.go
+++ b/pennsieve/integrations.go
@@ -1,0 +1,37 @@
+package pennsieve
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/pennsieve/processor-pre-ttl-sync/models"
+	"github.com/pennsieve/processor-pre-ttl-sync/util"
+	"io"
+	"net/http"
+)
+
+func (s *Session) GetIntegration(integrationID string) (models.Integration, error) {
+	url := fmt.Sprintf("%s/integrations/%s", s.API2Host, integrationID)
+
+	res, err := s.InvokePennsieve(http.MethodGet, url, nil)
+	if err != nil {
+		return models.Integration{}, err
+	}
+	defer util.CloseAndWarn(res)
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return models.Integration{}, fmt.Errorf("error reading response from GET %s: %w", url, err)
+	}
+
+	var integration models.Integration
+	if err := json.Unmarshal(body, &integration); err != nil {
+		rawResponse := string(body)
+		return models.Integration{}, fmt.Errorf(
+			"error unmarshalling response [%s] from GET %s: %w",
+			rawResponse,
+			url,
+			err)
+	}
+
+	return integration, nil
+}

--- a/pennsieve/invoke.go
+++ b/pennsieve/invoke.go
@@ -1,0 +1,40 @@
+package pennsieve
+
+import (
+	"fmt"
+	"github.com/pennsieve/processor-pre-ttl-sync/util"
+	"io"
+	"net/http"
+)
+
+type Session struct {
+	Token    string
+	APIHost  string
+	API2Host string
+}
+
+func NewSession(sessionToken, apiHost, api2Host string) *Session {
+	return &Session{
+		Token:    sessionToken,
+		APIHost:  apiHost,
+		API2Host: api2Host}
+}
+
+func (s *Session) newPennsieveRequest(method string, url string, body io.Reader) (*http.Request, error) {
+	request, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GET %s request: %w", url, err)
+	}
+	request.Header.Add("accept", "application/json")
+	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.Token))
+	return request, nil
+}
+
+func (s *Session) InvokePennsieve(method string, url string, body io.Reader) (*http.Response, error) {
+
+	req, err := s.newPennsieveRequest(method, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("error creating %s %s request: %w", method, url, err)
+	}
+	return util.Invoke(req)
+}

--- a/preprocessor/env.go
+++ b/preprocessor/env.go
@@ -1,0 +1,54 @@
+package preprocessor
+
+import (
+	"fmt"
+	"os"
+)
+
+const IntegrationIDKey = "INTEGRATION_ID"
+const InputDirectoryKey = "INPUT_DIR"
+const OutputDirectoryKey = "OUTPUT_DIR"
+const SessionTokenKey = "SESSION_TOKEN"
+const PennsieveAPIHostKey = "PENNSIEVE_API_HOST"
+const PennsieveAPI2HostKey = "PENNSIEVE_API_HOST2"
+
+func FromEnv() (*TTLSyncPreProcessor, error) {
+	integrationID, err := LookupRequiredEnvVar(IntegrationIDKey)
+	if err != nil {
+		return nil, err
+	}
+	inputDirectory, err := LookupRequiredEnvVar(InputDirectoryKey)
+	if err != nil {
+		return nil, err
+	}
+	outputDirectory, err := LookupRequiredEnvVar(OutputDirectoryKey)
+	if err != nil {
+		return nil, err
+	}
+	sessionToken, err := LookupRequiredEnvVar(SessionTokenKey)
+	if err != nil {
+		return nil, err
+	}
+	apiHost, err := LookupRequiredEnvVar(PennsieveAPIHostKey)
+	if err != nil {
+		return nil, err
+	}
+	api2Host, err := LookupRequiredEnvVar(PennsieveAPI2HostKey)
+	if err != nil {
+		return nil, err
+	}
+	return NewTTLSyncPreProcessor(integrationID,
+		inputDirectory,
+		outputDirectory,
+		sessionToken,
+		apiHost,
+		api2Host), nil
+}
+
+func LookupRequiredEnvVar(key string) (string, error) {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return "", fmt.Errorf("no %s set", key)
+	}
+	return value, nil
+}

--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -1,0 +1,93 @@
+package preprocessor
+
+import (
+	"encoding/json"
+	"fmt"
+	extfiles "github.com/pennsieve/processor-pre-external-files/models"
+	"github.com/pennsieve/processor-pre-ttl-sync/logging"
+	"github.com/pennsieve/processor-pre-ttl-sync/pennsieve"
+	"github.com/pennsieve/processor-pre-ttl-sync/util"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var logger = logging.PackageLogger("preprocessor")
+
+const DatasetNodeIDPrefix = "N:dataset:"
+
+const TTLEndpointPattern = "https://cassava.ucsd.edu/sparc/datasets/%s/LATEST/%s"
+
+var TTLFileNames = []string{"curation-export.ttl", "curation-export.json"}
+
+const ExternalFilesConfigName = "external-files.json"
+
+type TTLSyncPreProcessor struct {
+	IntegrationID   string
+	InputDirectory  string
+	OutputDirectory string
+	Pennsieve       *pennsieve.Session
+}
+
+func NewTTLSyncPreProcessor(
+	integrationID string,
+	inputDirectory string,
+	outputDirectory string,
+	sessionToken string,
+	apiHost string,
+	api2Host string) *TTLSyncPreProcessor {
+	session := pennsieve.NewSession(sessionToken, apiHost, api2Host)
+	return &TTLSyncPreProcessor{
+		IntegrationID:   integrationID,
+		InputDirectory:  inputDirectory,
+		OutputDirectory: outputDirectory,
+		Pennsieve:       session,
+	}
+}
+
+func (m *TTLSyncPreProcessor) Run() error {
+	logger.Info("processing integration", slog.String("integrationID", m.IntegrationID))
+	integration, err := m.Pennsieve.GetIntegration(m.IntegrationID)
+	if err != nil {
+		return err
+	}
+	datasetID := integration.DatasetNodeID
+	logger.Info("constructing external file config for dataset", slog.String("datasetID", datasetID))
+
+	datasetUUID, err := ExtractDatasetUUID(datasetID)
+	if err != nil {
+		return err
+	}
+	var externalFiles extfiles.ExternalFileParams
+	for _, ttlFile := range TTLFileNames {
+		ttlFileURL := fmt.Sprintf(TTLEndpointPattern, datasetUUID, ttlFile)
+		externalFiles = append(externalFiles, extfiles.ExternalFileParam{
+			URL:  ttlFileURL,
+			Name: ttlFile,
+		})
+		logger.Info("added TTL file URL", slog.String("url", ttlFileURL))
+	}
+
+	externalFilesConfigPath := filepath.Join(m.InputDirectory, ExternalFilesConfigName)
+	externalFilesConfigFile, err := os.Create(externalFilesConfigPath)
+	if err != nil {
+		return fmt.Errorf("error creating file %s: %w", externalFilesConfigPath, err)
+	}
+	defer util.CloseFileAndWarn(externalFilesConfigFile)
+
+	if err := json.NewEncoder(externalFilesConfigFile).Encode(externalFiles); err != nil {
+		return fmt.Errorf("error encoding external file config to path %s: %w", externalFilesConfigPath, err)
+	}
+	logger.Info("wrote external files config", slog.String("path", externalFilesConfigPath))
+
+	return nil
+}
+
+func ExtractDatasetUUID(datasetID string) (string, error) {
+	if datasetUUID, asExpected := strings.CutPrefix(datasetID, DatasetNodeIDPrefix); asExpected {
+		return datasetUUID, nil
+	} else {
+		return "", fmt.Errorf("datasetID %s missing expected prefix: %s", datasetID, DatasetNodeIDPrefix)
+	}
+}

--- a/preprocessor/preprocessor_test.go
+++ b/preprocessor/preprocessor_test.go
@@ -1,0 +1,97 @@
+package preprocessor
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/google/uuid"
+	extfiles "github.com/pennsieve/processor-pre-external-files/models"
+	"github.com/pennsieve/processor-pre-ttl-sync/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtractDatasetUUID(t *testing.T) {
+	t.Run("correct format", func(t *testing.T) {
+		expectedDatasetUUID := uuid.NewString()
+		datasetUUID, err := ExtractDatasetUUID(newDatasetIDWithUUID(expectedDatasetUUID))
+		require.NoError(t, err)
+		assert.Equal(t, expectedDatasetUUID, datasetUUID)
+	})
+
+	t.Run("incorrect format", func(t *testing.T) {
+		wrongFormatID := uuid.NewString()
+		_, err := ExtractDatasetUUID(wrongFormatID)
+		assert.ErrorContainsf(t, err, DatasetNodeIDPrefix, "error message missing Node ID Prefix")
+		assert.ErrorContainsf(t, err, wrongFormatID, "error message missing passed in datasetID")
+
+	})
+}
+func TestRun(t *testing.T) {
+	datasetId := newDatasetID()
+
+	integrationID := uuid.NewString()
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+	sessionToken := uuid.NewString()
+	mockServer := newMockServer(t, integrationID, datasetId)
+	defer mockServer.Close()
+
+	ttlSyncPP := NewTTLSyncPreProcessor(integrationID, inputDir, outputDir, sessionToken, mockServer.URL, mockServer.URL)
+
+	require.NoError(t, ttlSyncPP.Run())
+
+	expectedExternalFilesConfigPath := filepath.Join(inputDir, ExternalFilesConfigName)
+	if assert.FileExists(t, expectedExternalFilesConfigPath) {
+		actual, err := os.Open(expectedExternalFilesConfigPath)
+		require.NoError(t, err)
+		var actualConfig extfiles.ExternalFileParams
+		require.NoError(t, json.NewDecoder(actual).Decode(&actualConfig))
+
+		expectedDatasetUUID, err := ExtractDatasetUUID(datasetId)
+		require.NoError(t, err)
+
+		assert.Len(t, actualConfig, len(TTLFileNames))
+		for i := range TTLFileNames {
+			expectedName := TTLFileNames[i]
+			actualURLConfig := actualConfig[i]
+			assert.Equal(t, expectedName, actualURLConfig.Name)
+			assert.Equal(t, fmt.Sprintf(TTLEndpointPattern, expectedDatasetUUID, expectedName), actualURLConfig.URL)
+			assert.Nil(t, actualURLConfig.Auth)
+			assert.Nil(t, actualURLConfig.Query)
+		}
+	}
+
+}
+
+func newDatasetID() string {
+	return newDatasetIDWithUUID(uuid.NewString())
+}
+
+func newDatasetIDWithUUID(datasetUUID string) string {
+	return fmt.Sprintf("%s%s", DatasetNodeIDPrefix, datasetUUID)
+}
+
+func newMockServer(t *testing.T, integrationID string, datasetID string) *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc(fmt.Sprintf("/integrations/%s", integrationID), func(writer http.ResponseWriter, request *http.Request) {
+		require.Equal(t, http.MethodGet, request.Method, "expected method %s for %s, got %s", http.MethodGet, request.URL, request.Method)
+		integration := models.Integration{
+			Uuid:          uuid.NewString(),
+			ApplicationID: 0,
+			DatasetNodeID: datasetID,
+		}
+		integrationResponse, err := json.Marshal(integration)
+		require.NoError(t, err)
+		_, err = writer.Write(integrationResponse)
+		require.NoError(t, err)
+	})
+	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		require.Fail(t, "unexpected call to Pennsieve", "%s %s", request.Method, request.URL)
+	})
+	return httptest.NewServer(mux)
+}

--- a/run-integration-test.sh
+++ b/run-integration-test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+
+if [ "$#" -eq 0 ]; then
+  echo "must pass an env file. See Readme.md"
+  exit 1
+fi
+
+for env_file in "$@"; do
+    if [ -f "$env_file" ]; then
+        set -o allexport && . "$env_file" && set +o allexport
+    else
+        echo "environment file $env_file is missing"
+        exit 1
+    fi
+done
+
+root_dir=$(pwd)
+# the local directory in this directory that docker compose binds to /service/data in the container
+local_volume="data"
+docker_volume="/service/data"
+
+if [ -z "$INTEGRATION_ID" ]; then
+  echo "no value set for INTEGRATION_ID; exiting"
+  exit 1
+fi
+
+echo "** deleting $root_dir/$local_volume **"
+rm -fR "$local_volume"
+
+echo "** creating required directories **"
+# input
+if [[ "$INPUT_DIR" =~ ^$docker_volume ]]; then
+  local_input_dir=${root_dir}/${local_volume}/${INPUT_DIR#$docker_volume/}
+  mkdir -p "$local_input_dir"
+  echo "created $local_input_dir"
+else
+  echo "expected $INPUT_DIR to start with $docker_volume; exiting"
+  exit 1
+fi
+
+# output
+if [[ "$OUTPUT_DIR" =~ ^$docker_volume ]]; then
+  local_output_dir=${root_dir}/${local_volume}/${OUTPUT_DIR#$docker_volume/}
+  mkdir -p "$local_output_dir"
+  echo "created $local_output_dir"
+else
+  echo "expected $OUTPUT_DIR to start with $docker_volume; exiting"
+  exit 1
+fi
+
+docker-compose up --build
+

--- a/util/http.go
+++ b/util/http.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"fmt"
+	"github.com/pennsieve/processor-pre-external-files/logging"
+	"io"
+	"net/http"
+)
+
+var logger = logging.PackageLogger("util")
+
+func CloseAndWarn(response *http.Response) {
+	if err := response.Body.Close(); err != nil {
+		logger.Warn("error closing response body from %s %s: %w", response.Request.Method, response.Request.URL, err)
+	}
+}
+
+func Invoke(request *http.Request) (*http.Response, error) {
+
+	res, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("error invoking %s %s: %w", request.Method, request.URL, err)
+	}
+	if err := checkHTTPStatus(res); err != nil {
+		// if there was an error, checkHTTPStatus read the body
+		if closeError := res.Body.Close(); closeError != nil {
+			logger.Warn("error closing response body from %s %s: %w", request.Method, request.URL, closeError)
+		}
+		return nil, err
+	}
+	return res, nil
+}
+
+// checkHTTPStatus returns an error if 400 <= response status code < 600. Otherwise, returns nil.
+// If an error is being returned, this function will consume response.Body so it should be
+// called before the caller has read the body.
+func checkHTTPStatus(response *http.Response) error {
+	readBody := func() []byte {
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			return []byte(fmt.Sprintf("<unable to read body: %s>", err.Error()))
+		}
+		return body
+	}
+	if http.StatusBadRequest <= response.StatusCode && response.StatusCode < 600 {
+		responseBody := readBody()
+		var displayBody string
+		if len(responseBody) > 1000 {
+			displayBody = fmt.Sprintf("<truncated for logging> %s", string(responseBody[:1000]))
+		}
+		displayBody = string(responseBody)
+		errorType := "client"
+		if response.StatusCode >= http.StatusInternalServerError {
+			errorType = "server"
+		}
+		return fmt.Errorf("%s error %s calling %s %s; response body: %s",
+			errorType,
+			response.Status,
+			response.Request.Method,
+			response.Request.URL,
+			displayBody)
+	}
+	return nil
+}

--- a/util/os.go
+++ b/util/os.go
@@ -1,0 +1,11 @@
+package util
+
+import (
+	"os"
+)
+
+func CloseFileAndWarn(file *os.File) {
+	if err := file.Close(); err != nil {
+		logger.Warn("error closing file %s: %w", file.Name(), err)
+	}
+}


### PR DESCRIPTION
First pass where processor gets dataset node id from the integration and writes a config for the external-files pre-processor at `$INPUT_DIR/external-files.json` with two URLs from the external TTL endpoint. One a JSON file and one a TTL file. Not sure if we really need both. Or if there are other files at that endpoint that we should be downloading.