### PR TITLE
Fixes for integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Given a dataset node ID, produces the external URLs for the latest TTL files in the format expected
 by [processor-pre-external-files](https://github.com/Pennsieve/processor-pre-external-files)
 
+The file is written to `$INPUT_DIR/external-files.json`
+
 To build:
 
 `docker build -t pennsieve/ttl-sync-pre-processor .`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   
   ttl-sync-pre-processor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   
-  ttl-sync-pre-processor:
+  pre-processor:
     env_file:
       - dev.env
     image: pennsieve/ttl-sync-pre-processor

--- a/main.go
+++ b/main.go
@@ -10,14 +10,13 @@ import (
 var logger = logging.PackageLogger("main")
 
 func main() {
-	logger.Info("Hello")
 	m, err := preprocessor.FromEnv()
 	if err != nil {
 		logger.Error("error creating preprocessor", slog.Any("error", err))
 		os.Exit(1)
 	}
 
-	logger.Info("created ExternalFilesPreProcessor",
+	logger.Info("created TTLSyncPreProcessor",
 		slog.String("integrationID", m.IntegrationID),
 		slog.String("inputDirectory", m.InputDirectory),
 		slog.String("outputDirectory", m.OutputDirectory),

--- a/run-integration-test.sh
+++ b/run-integration-test.sh
@@ -49,5 +49,5 @@ else
   exit 1
 fi
 
-docker-compose up --build
+docker compose up --build
 

--- a/run-integration-test.sh
+++ b/run-integration-test.sh
@@ -49,5 +49,5 @@ else
   exit 1
 fi
 
-docker compose up --build
-
+#docker compose up --build
+docker compose run --build --rm pre-processor


### PR DESCRIPTION
A couple of changes after running the integration test with Docker Engine 27.0.3.

The `docker-compose` command is missing and is replaced by `docker compose ...`

Docker complained that the `version` field of `docker-compose.yml` is obsolete, so PR removes it.

Also fixed a typo and added some more info to README.