### PR TITLE
Configurable TTL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ To run integration test:
 2. Copy `dev.env.example` to `dev.env`
 3. In dev.env update SESSION_TOKEN with a valid token and INTEGRATION_ID with the id from the first step.
 4. Run `./run-integration-test.sh dev.env`
+
+If `ENVIRONMENT=dev` is in `dev.env`, then the processor will try to fetch the curation-export files from a test server
+and you will have to make sure that there are files there to find.
+
+If `ENVIRONMENT=prod` is in `dev.env', the processor will use the real SPARC endpoint to find the curation-export files.

--- a/dev.env.example
+++ b/dev.env.example
@@ -1,3 +1,4 @@
+ENVIRONMENT=dev
 SESSION_TOKEN=<token>
 PENNSIEVE_API_HOST=https://api.pennsieve.net
 PENNSIEVE_API_HOST2=https://api2.pennsieve.net

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.21
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6
+	github.com/pennsieve/processor-pre-external-files/client v0.0.0
+	github.com/pennsieve/processor-pre-external-files/service v0.0.0
 	github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/pennsieve/processor-pre-external-files/client v0.0.0
 	github.com/pennsieve/processor-pre-external-files/service v0.0.0
-	github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb
+	github.com/pennsieve/processor-pre-metadata/service v0.0.0-20241017165057-c424ef30521c
 	github.com/stretchr/testify v1.9.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,8 @@ go 1.21
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c
+	github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6
+	github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6 h1:g39psgMsM7IYgTUW83XcvHDH4ujnO6jGf4+4OemBS6Q=
-github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6/go.mod h1:093KHBU6h4euZGXJGDbhMESM9oNwJGY1DkKFwCV/H5o=
+github.com/pennsieve/processor-pre-external-files/client v0.0.0 h1:Tfln00kWIynTJiWtawEU7Jap4MbBwBW9weZgMNjcR30=
+github.com/pennsieve/processor-pre-external-files/client v0.0.0/go.mod h1:GLhbrJKm77KLlLusBn9/QkY43LcC1nKvw3OJ8HuwZWM=
+github.com/pennsieve/processor-pre-external-files/service v0.0.0 h1:tkYe5wIbZvVoBrGqf/dfwTifJHwAtAI3USJLu2XdUrw=
+github.com/pennsieve/processor-pre-external-files/service v0.0.0/go.mod h1:TLQ9x5jeEUzCkjSqqFNkq3q2iGdRisiS6yn2eU1Y2Ls=
 github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb h1:WbuPKDDUXrJ1SHAdlX6sHpIwdygFQBh5scZsgJtBnOc=
 github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb/go.mod h1:9X84Hq5DCNzI8G+Xl/D/Fd0iJXpuTy7YWOQQghEtOSs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,10 @@ github.com/pennsieve/processor-pre-external-files/client v0.0.0 h1:Tfln00kWIynTJ
 github.com/pennsieve/processor-pre-external-files/client v0.0.0/go.mod h1:GLhbrJKm77KLlLusBn9/QkY43LcC1nKvw3OJ8HuwZWM=
 github.com/pennsieve/processor-pre-external-files/service v0.0.0 h1:tkYe5wIbZvVoBrGqf/dfwTifJHwAtAI3USJLu2XdUrw=
 github.com/pennsieve/processor-pre-external-files/service v0.0.0/go.mod h1:TLQ9x5jeEUzCkjSqqFNkq3q2iGdRisiS6yn2eU1Y2Ls=
-github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb h1:WbuPKDDUXrJ1SHAdlX6sHpIwdygFQBh5scZsgJtBnOc=
-github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb/go.mod h1:9X84Hq5DCNzI8G+Xl/D/Fd0iJXpuTy7YWOQQghEtOSs=
+github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b h1:Gct/J1FVYjsRWniZtf5EZ2cAjT8uuRcQfL0au+7QpqI=
+github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
+github.com/pennsieve/processor-pre-metadata/service v0.0.0-20241017165057-c424ef30521c h1:MSlUoHWh7Y4KPtB5IR+63HJjZSzIQlQb5hK0zho4r6I=
+github.com/pennsieve/processor-pre-metadata/service v0.0.0-20241017165057-c424ef30521c/go.mod h1:JH+qfs4UXrPjYIaWBSvkH35jQLnOCk3vPfhUvOHCVl8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c h1:05YljpV++86gZsb2C5brFLz+lX5GRzpx5rW7GxcKpAk=
-github.com/pennsieve/processor-pre-external-files v0.0.0-20240731144242-d3537f64b83c/go.mod h1:amoXpOYDD+iyV2nkqE+oyu7C85iFGnhEPN9Bfwb7+nE=
+github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6 h1:g39psgMsM7IYgTUW83XcvHDH4ujnO6jGf4+4OemBS6Q=
+github.com/pennsieve/processor-pre-external-files/service v0.0.0-20240829161044-bdc1287f4df6/go.mod h1:093KHBU6h4euZGXJGDbhMESM9oNwJGY1DkKFwCV/H5o=
+github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb h1:WbuPKDDUXrJ1SHAdlX6sHpIwdygFQBh5scZsgJtBnOc=
+github.com/pennsieve/processor-pre-metadata v0.0.0-20240829200621-01175e9a81cb/go.mod h1:9X84Hq5DCNzI8G+Xl/D/Fd0iJXpuTy7YWOQQghEtOSs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 		slog.String("outputDirectory", m.OutputDirectory),
 		slog.String("apiHost", m.Pennsieve.APIHost),
 		slog.String("api2Host", m.Pennsieve.API2Host),
+		slog.String("curationExportURLPattern", m.TTLURLPattern),
 	)
 
 	if err := m.Run(); err != nil {

--- a/preprocessor/env.go
+++ b/preprocessor/env.go
@@ -12,6 +12,8 @@ const SessionTokenKey = "SESSION_TOKEN"
 const PennsieveAPIHostKey = "PENNSIEVE_API_HOST"
 const PennsieveAPI2HostKey = "PENNSIEVE_API_HOST2"
 
+const ProdTTLHost = "https://cassava.ucsd.edu"
+
 func FromEnv() (*TTLSyncPreProcessor, error) {
 	integrationID, err := LookupRequiredEnvVar(IntegrationIDKey)
 	if err != nil {
@@ -42,7 +44,8 @@ func FromEnv() (*TTLSyncPreProcessor, error) {
 		outputDirectory,
 		sessionToken,
 		apiHost,
-		api2Host), nil
+		api2Host,
+		ProdTTLHost), nil
 }
 
 func LookupRequiredEnvVar(key string) (string, error) {

--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	extfiles "github.com/pennsieve/processor-pre-external-files/client/models"
 	extfilesproc "github.com/pennsieve/processor-pre-external-files/service/preprocessor"
-	metadataproc "github.com/pennsieve/processor-pre-metadata/preprocessor"
+	metadataproc "github.com/pennsieve/processor-pre-metadata/service/preprocessor"
 	"github.com/pennsieve/processor-pre-ttl-sync/logging"
 	"github.com/pennsieve/processor-pre-ttl-sync/pennsieve"
 	"github.com/pennsieve/processor-pre-ttl-sync/util"

--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -3,7 +3,9 @@ package preprocessor
 import (
 	"encoding/json"
 	"fmt"
-	extfiles "github.com/pennsieve/processor-pre-external-files/models"
+	extfilesmodels "github.com/pennsieve/processor-pre-external-files/service/models"
+	extfiles "github.com/pennsieve/processor-pre-external-files/service/preprocessor"
+	metadata "github.com/pennsieve/processor-pre-metadata/preprocessor"
 	"github.com/pennsieve/processor-pre-ttl-sync/logging"
 	"github.com/pennsieve/processor-pre-ttl-sync/pennsieve"
 	"github.com/pennsieve/processor-pre-ttl-sync/util"
@@ -17,17 +19,20 @@ var logger = logging.PackageLogger("preprocessor")
 
 const DatasetNodeIDPrefix = "N:dataset:"
 
-const TTLEndpointPattern = "https://cassava.ucsd.edu/sparc/datasets/%s/LATEST/%s"
+const TTLEndpointPattern = "/sparc/datasets/%s/LATEST/%s"
 
 var TTLFileNames = []string{"curation-export.ttl", "curation-export.json"}
 
 const ExternalFilesConfigName = "external-files.json"
 
 type TTLSyncPreProcessor struct {
-	IntegrationID   string
-	InputDirectory  string
-	OutputDirectory string
-	Pennsieve       *pennsieve.Session
+	IntegrationID         string
+	InputDirectory        string
+	OutputDirectory       string
+	Pennsieve             *pennsieve.Session
+	TTLURLPattern         string
+	ExternalFileProcessor *extfiles.ExternalFilesPreProcessor
+	MetadataProcessor     *metadata.MetadataPreProcessor
 }
 
 func NewTTLSyncPreProcessor(
@@ -36,13 +41,24 @@ func NewTTLSyncPreProcessor(
 	outputDirectory string,
 	sessionToken string,
 	apiHost string,
-	api2Host string) *TTLSyncPreProcessor {
+	api2Host string,
+	ttlHost string) *TTLSyncPreProcessor {
 	session := pennsieve.NewSession(sessionToken, apiHost, api2Host)
+
+	metadataPreProcessor := metadata.NewMetadataPreProcessor(integrationID, inputDirectory, outputDirectory, sessionToken, apiHost, api2Host, 0)
+
+	externalFilesConfigPath := filepath.Join(inputDirectory, ExternalFilesConfigName)
+	extFilePreProcessor := extfiles.NewExternalFilesPreProcessor(integrationID, inputDirectory, outputDirectory, externalFilesConfigPath)
+
+	ttlURLPattern := ttlHost + TTLEndpointPattern
 	return &TTLSyncPreProcessor{
-		IntegrationID:   integrationID,
-		InputDirectory:  inputDirectory,
-		OutputDirectory: outputDirectory,
-		Pennsieve:       session,
+		IntegrationID:         integrationID,
+		InputDirectory:        inputDirectory,
+		OutputDirectory:       outputDirectory,
+		Pennsieve:             session,
+		ExternalFileProcessor: extFilePreProcessor,
+		MetadataProcessor:     metadataPreProcessor,
+		TTLURLPattern:         ttlURLPattern,
 	}
 }
 
@@ -53,23 +69,32 @@ func (m *TTLSyncPreProcessor) Run() error {
 		return err
 	}
 	datasetID := integration.DatasetNodeID
+
+	logger.Info("Running TTL sync", slog.String("datasetID", datasetID))
+
+	m.MetadataProcessor = m.MetadataProcessor.WithDatasetID(datasetID)
+
+	if err := m.MetadataProcessor.Run(); err != nil {
+		return err
+	}
+
 	logger.Info("constructing external file config for dataset", slog.String("datasetID", datasetID))
 
 	datasetUUID, err := ExtractDatasetUUID(datasetID)
 	if err != nil {
 		return err
 	}
-	var externalFiles extfiles.ExternalFileParams
+	var externalFiles extfilesmodels.ExternalFileParams
 	for _, ttlFile := range TTLFileNames {
-		ttlFileURL := fmt.Sprintf(TTLEndpointPattern, datasetUUID, ttlFile)
-		externalFiles = append(externalFiles, extfiles.ExternalFileParam{
+		ttlFileURL := fmt.Sprintf(m.TTLURLPattern, datasetUUID, ttlFile)
+		externalFiles = append(externalFiles, extfilesmodels.ExternalFileParam{
 			URL:  ttlFileURL,
 			Name: ttlFile,
 		})
 		logger.Info("added TTL file URL", slog.String("url", ttlFileURL))
 	}
 
-	externalFilesConfigPath := filepath.Join(m.InputDirectory, ExternalFilesConfigName)
+	externalFilesConfigPath := m.ExternalFileProcessor.ConfigFile
 	externalFilesConfigFile, err := os.Create(externalFilesConfigPath)
 	if err != nil {
 		return fmt.Errorf("error creating file %s: %w", externalFilesConfigPath, err)
@@ -80,7 +105,18 @@ func (m *TTLSyncPreProcessor) Run() error {
 		return fmt.Errorf("error encoding external file config to path %s: %w", externalFilesConfigPath, err)
 	}
 	logger.Info("wrote external files config", slog.String("path", externalFilesConfigPath))
+	if err := m.downloadTTLFiles(); err != nil {
+		return err
+	}
+	return nil
+}
 
+func (m *TTLSyncPreProcessor) downloadTTLFiles() error {
+	logger.Info("downloading TTL files")
+	if err := m.ExternalFileProcessor.Run(); err != nil {
+		return err
+	}
+	logger.Info("downloaded TTL files")
 	return nil
 }
 

--- a/preprocessor/preprocessor.go
+++ b/preprocessor/preprocessor.go
@@ -3,9 +3,9 @@ package preprocessor
 import (
 	"encoding/json"
 	"fmt"
-	extfilesmodels "github.com/pennsieve/processor-pre-external-files/service/models"
-	extfiles "github.com/pennsieve/processor-pre-external-files/service/preprocessor"
-	metadata "github.com/pennsieve/processor-pre-metadata/preprocessor"
+	extfiles "github.com/pennsieve/processor-pre-external-files/client/models"
+	extfilesproc "github.com/pennsieve/processor-pre-external-files/service/preprocessor"
+	metadataproc "github.com/pennsieve/processor-pre-metadata/preprocessor"
 	"github.com/pennsieve/processor-pre-ttl-sync/logging"
 	"github.com/pennsieve/processor-pre-ttl-sync/pennsieve"
 	"github.com/pennsieve/processor-pre-ttl-sync/util"
@@ -31,8 +31,8 @@ type TTLSyncPreProcessor struct {
 	OutputDirectory       string
 	Pennsieve             *pennsieve.Session
 	TTLURLPattern         string
-	ExternalFileProcessor *extfiles.ExternalFilesPreProcessor
-	MetadataProcessor     *metadata.MetadataPreProcessor
+	ExternalFileProcessor *extfilesproc.ExternalFilesPreProcessor
+	MetadataProcessor     *metadataproc.MetadataPreProcessor
 }
 
 func NewTTLSyncPreProcessor(
@@ -45,10 +45,10 @@ func NewTTLSyncPreProcessor(
 	ttlHost string) *TTLSyncPreProcessor {
 	session := pennsieve.NewSession(sessionToken, apiHost, api2Host)
 
-	metadataPreProcessor := metadata.NewMetadataPreProcessor(integrationID, inputDirectory, outputDirectory, sessionToken, apiHost, api2Host, 0)
+	metadataPreProcessor := metadataproc.NewMetadataPreProcessor(integrationID, inputDirectory, outputDirectory, sessionToken, apiHost, api2Host, 0)
 
 	externalFilesConfigPath := filepath.Join(inputDirectory, ExternalFilesConfigName)
-	extFilePreProcessor := extfiles.NewExternalFilesPreProcessor(integrationID, inputDirectory, outputDirectory, externalFilesConfigPath)
+	extFilePreProcessor := extfilesproc.NewExternalFilesPreProcessor(integrationID, inputDirectory, outputDirectory, externalFilesConfigPath)
 
 	ttlURLPattern := ttlHost + TTLEndpointPattern
 	return &TTLSyncPreProcessor{
@@ -84,10 +84,10 @@ func (m *TTLSyncPreProcessor) Run() error {
 	if err != nil {
 		return err
 	}
-	var externalFiles extfilesmodels.ExternalFileParams
+	var externalFiles extfiles.ExternalFileParams
 	for _, ttlFile := range TTLFileNames {
 		ttlFileURL := fmt.Sprintf(m.TTLURLPattern, datasetUUID, ttlFile)
-		externalFiles = append(externalFiles, extfilesmodels.ExternalFileParam{
+		externalFiles = append(externalFiles, extfiles.ExternalFileParam{
 			URL:  ttlFileURL,
 			Name: ttlFile,
 		})

--- a/preprocessor/preprocessor_test.go
+++ b/preprocessor/preprocessor_test.go
@@ -1,13 +1,15 @@
 package preprocessor
 
 import (
+	crypto "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
-	extfiles "github.com/pennsieve/processor-pre-external-files/models"
+	extfiles "github.com/pennsieve/processor-pre-external-files/service/models"
 	"github.com/pennsieve/processor-pre-ttl-sync/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -31,21 +33,54 @@ func TestExtractDatasetUUID(t *testing.T) {
 
 	})
 }
+
+func TestNewTTLSyncPreProcessor(t *testing.T) {
+	integrationID := uuid.NewString()
+	inputDirectory := uuid.NewString()
+	outputDirectory := uuid.NewString()
+	sessionToken := uuid.NewString()
+	apiHost := uuid.NewString()
+	api2Host := uuid.NewString()
+	ttlHost := uuid.NewString()
+
+	p := NewTTLSyncPreProcessor(integrationID, inputDirectory, outputDirectory, sessionToken, apiHost, api2Host, ttlHost)
+
+	assert.Equal(t, integrationID, p.IntegrationID)
+	assert.Equal(t, inputDirectory, p.InputDirectory)
+	assert.Equal(t, outputDirectory, p.OutputDirectory)
+	assert.Equal(t, sessionToken, p.Pennsieve.Token)
+	assert.Equal(t, apiHost, p.Pennsieve.APIHost)
+	assert.Equal(t, api2Host, p.Pennsieve.API2Host)
+	assert.Equal(t, ttlHost+TTLEndpointPattern, p.TTLURLPattern)
+	assert.Equal(t, inputDirectory, p.ExternalFileProcessor.InputDirectory)
+	assert.Equal(t, filepath.Join(inputDirectory, ExternalFilesConfigName), p.ExternalFileProcessor.ConfigFile)
+}
+
 func TestRun(t *testing.T) {
-	datasetId := newDatasetID()
+	datasetUUID := uuid.NewString()
+	datasetId := newDatasetIDWithUUID(datasetUUID)
 
 	integrationID := uuid.NewString()
 	inputDir := t.TempDir()
 	outputDir := t.TempDir()
 	sessionToken := uuid.NewString()
-	mockServer := newMockServer(t, integrationID, datasetId)
+	expectedTTLFiles := newExpectedTTLFiles(t, datasetUUID, inputDir)
+
+	// empty graph schema. We're not testing the metadata processor, just that we are configuring
+	// it with the correct parameters
+	expectedFiles := append(expectedTTLFiles, ExpectedFile{
+		filePath: filepath.Join(inputDir, "metadata", "schema", "graphSchema.json"),
+		urlPath:  fmt.Sprintf("/models/v1/datasets/%s/concepts/schema/graph", datasetId),
+		content:  []byte("[]"),
+	})
+
+	mockServer := newMockServer(t, integrationID, datasetId, expectedFiles)
 	defer mockServer.Close()
 
-	ttlSyncPP := NewTTLSyncPreProcessor(integrationID, inputDir, outputDir, sessionToken, mockServer.URL, mockServer.URL)
-
+	ttlSyncPP := NewTTLSyncPreProcessor(integrationID, inputDir, outputDir, sessionToken, mockServer.URL, mockServer.URL, mockServer.URL)
 	require.NoError(t, ttlSyncPP.Run())
 
-	expectedExternalFilesConfigPath := filepath.Join(inputDir, ExternalFilesConfigName)
+	expectedExternalFilesConfigPath := ttlSyncPP.ExternalFileProcessor.ConfigFile
 	if assert.FileExists(t, expectedExternalFilesConfigPath) {
 		actual, err := os.Open(expectedExternalFilesConfigPath)
 		require.NoError(t, err)
@@ -60,9 +95,18 @@ func TestRun(t *testing.T) {
 			expectedName := TTLFileNames[i]
 			actualURLConfig := actualConfig[i]
 			assert.Equal(t, expectedName, actualURLConfig.Name)
-			assert.Equal(t, fmt.Sprintf(TTLEndpointPattern, expectedDatasetUUID, expectedName), actualURLConfig.URL)
+			assert.Equal(t, fmt.Sprintf(ttlSyncPP.TTLURLPattern, expectedDatasetUUID, expectedName), actualURLConfig.URL)
 			assert.Nil(t, actualURLConfig.Auth)
 			assert.Nil(t, actualURLConfig.Query)
+		}
+	}
+	for _, expectedFile := range expectedFiles {
+		if assert.FileExists(t, expectedFile.filePath) {
+			actualContent, err := os.ReadFile(expectedFile.filePath)
+			if assert.NoError(t, err) {
+				assert.Equal(t, expectedFile.content, actualContent)
+			}
+
 		}
 	}
 
@@ -76,7 +120,30 @@ func newDatasetIDWithUUID(datasetUUID string) string {
 	return fmt.Sprintf("%s%s", DatasetNodeIDPrefix, datasetUUID)
 }
 
-func newMockServer(t *testing.T, integrationID string, datasetID string) *httptest.Server {
+type ExpectedFile struct {
+	filePath string
+	urlPath  string
+	content  []byte
+}
+
+func newExpectedTTLFiles(t *testing.T, datasetUUID string, inputDirectory string) []ExpectedFile {
+	var files []ExpectedFile
+	for _, ttlFileName := range TTLFileNames {
+		size := rand.Intn(1000) + 1
+		bytes := make([]byte, size)
+		_, err := crypto.Read(bytes)
+		require.NoError(t, err)
+
+		files = append(files, ExpectedFile{
+			filePath: filepath.Join(inputDirectory, ttlFileName),
+			urlPath:  fmt.Sprintf(TTLEndpointPattern, datasetUUID, ttlFileName),
+			content:  bytes,
+		})
+	}
+	return files
+}
+
+func newMockServer(t *testing.T, integrationID string, datasetID string, expectedFiles []ExpectedFile) *httptest.Server {
 	mux := http.NewServeMux()
 	mux.HandleFunc(fmt.Sprintf("/integrations/%s", integrationID), func(writer http.ResponseWriter, request *http.Request) {
 		require.Equal(t, http.MethodGet, request.Method, "expected method %s for %s, got %s", http.MethodGet, request.URL, request.Method)
@@ -90,8 +157,17 @@ func newMockServer(t *testing.T, integrationID string, datasetID string) *httpte
 		_, err = writer.Write(integrationResponse)
 		require.NoError(t, err)
 	})
+	for i := range expectedFiles {
+		// work around Go loop variable gotcha
+		expectedFile := expectedFiles[i]
+		mux.HandleFunc(expectedFile.urlPath, func(writer http.ResponseWriter, request *http.Request) {
+			require.Equal(t, http.MethodGet, request.Method, "expected method %s for %s, got %s", http.MethodGet, request.URL, request.Method)
+			_, err := writer.Write(expectedFile.content)
+			require.NoError(t, err)
+		})
+	}
 	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		require.Fail(t, "unexpected call to Pennsieve", "%s %s", request.Method, request.URL)
+		require.Fail(t, "unexpected call to mockServer", "%s %s", request.Method, request.URL)
 	})
 	return httptest.NewServer(mux)
 }

--- a/preprocessor/preprocessor_test.go
+++ b/preprocessor/preprocessor_test.go
@@ -72,7 +72,12 @@ func TestRun(t *testing.T) {
 		filePath: filepath.Join(inputDir, "metadata", "schema", "graphSchema.json"),
 		urlPath:  fmt.Sprintf("/models/v1/datasets/%s/concepts/schema/graph", datasetId),
 		content:  []byte("[]"),
-	})
+	},
+		ExpectedFile{
+			filePath: filepath.Join(inputDir, "metadata", "schema", "relationships.json"),
+			urlPath:  fmt.Sprintf("/models/datasets/%s/relationships", datasetId),
+			content:  []byte("[]"),
+		})
 
 	mockServer := newMockServer(t, integrationID, datasetId, expectedFiles)
 	defer mockServer.Close()

--- a/preprocessor/preprocessor_test.go
+++ b/preprocessor/preprocessor_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
-	extfiles "github.com/pennsieve/processor-pre-external-files/service/models"
+	extfiles "github.com/pennsieve/processor-pre-external-files/client/models"
 	"github.com/pennsieve/processor-pre-ttl-sync/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/util/http.go
+++ b/util/http.go
@@ -2,7 +2,7 @@ package util
 
 import (
 	"fmt"
-	"github.com/pennsieve/processor-pre-external-files/logging"
+	"github.com/pennsieve/processor-pre-ttl-sync/logging"
 	"io"
 	"net/http"
 )


### PR DESCRIPTION
Use environment name to determine which TTL endpoint to use.

Update versions of external file and metadata pre-processors.
